### PR TITLE
Ensure prefixed attribute options are handled

### DIFF
--- a/src/AttributeOptionMapper.php
+++ b/src/AttributeOptionMapper.php
@@ -14,9 +14,12 @@ final class AttributeOptionMapper extends DataMapper
 
     public function __invoke(Akeneo2AttributeOption $attributeOption): Magento2AttributeOption
     {
+        $optionCodes = explode('-', $attributeOption->getOptionCode());
+        $optionCode = count($optionCodes) >= 2 ? $optionCodes[1] : $attributeOption->getOptionCode();
+
         return Magento2AttributeOption::of(
             $attributeOption->getAttributeCode(),
-            $attributeOption->getOptionCode(),
+            $optionCode,
             $attributeOption->getLabel($this->defaultLocale) ?? $attributeOption->getOptionCode()
         );
     }

--- a/src/AttributeOptionMapper.php
+++ b/src/AttributeOptionMapper.php
@@ -15,7 +15,8 @@ final class AttributeOptionMapper extends DataMapper
     public function __invoke(Akeneo2AttributeOption $attributeOption): Magento2AttributeOption
     {
         $optionCodes = explode('-', $attributeOption->getOptionCode());
-        $optionCode = count($optionCodes) >= 2 ? $optionCodes[1] : $attributeOption->getOptionCode();
+        $optionCode = count($optionCodes) >= 2 ? implode('-', array_slice($optionCodes, 1)) :
+            $attributeOption->getOptionCode();
 
         return Magento2AttributeOption::of(
             $attributeOption->getAttributeCode(),

--- a/src/AttributeOptionMapper.php
+++ b/src/AttributeOptionMapper.php
@@ -14,15 +14,19 @@ final class AttributeOptionMapper extends DataMapper
 
     public function __invoke(Akeneo2AttributeOption $attributeOption): Magento2AttributeOption
     {
-        $optionCodes = explode('-', $attributeOption->getOptionCode());
-        $optionCode = count($optionCodes) >= 2 ? implode('-', array_slice($optionCodes, 1)) :
-            $attributeOption->getOptionCode();
-
         return Magento2AttributeOption::of(
             $attributeOption->getAttributeCode(),
-            $optionCode,
+            $this->obtainOptionCodeFromPrefixedOptionCode($attributeOption),
             $attributeOption->getLabel($this->defaultLocale) ?? $attributeOption->getOptionCode()
         );
+    }
+
+    private function obtainOptionCodeFromPrefixedOptionCode(Akeneo2AttributeOption $attributeOption)
+    {
+        $optionCodes = explode('-', $attributeOption->getOptionCode());
+        return count($optionCodes) >= 2 && $optionCodes[0] === $attributeOption->getAttributeCode() ?
+            implode('-', array_slice($optionCodes, 1)) :
+            $attributeOption->getOptionCode();
     }
 
     private $defaultLocale;

--- a/test/unit/AttributeOptionMapperTest.php
+++ b/test/unit/AttributeOptionMapperTest.php
@@ -21,4 +21,14 @@ class AttributeOptionMapperTest extends TestCase
         $expected = Magento2AttributeOption::of('size','large', 'Large');
         self::assertTrue($expected->equals($actual));
      }
+
+    public function testMapWithAttributeCodeAndOptionCode()
+    {
+        $input = AkeneoAttributeOption::of(AttributeOptionIdentifier::of('size', 'size-large'))
+            ->withLabel(LocalizedString::of('Large', 'en_GB'));
+        $mapper = AttributeOptionMapper::withDefaultLocale('en_GB');
+        $actual = $mapper($input);
+        $expected = Magento2AttributeOption::of('size','large', 'Large');
+        self::assertTrue($expected->equals($actual));
+    }
 }


### PR DESCRIPTION
# Overview

Remove prefixing of the attribute code to the attribute option code iff the is a prefix